### PR TITLE
change global variable name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,9 +28,9 @@ export default class VueSocketIO {
      */
     install(app){
 
-        app.config.globalProperties.$http = this.io;
-    app.config.globalProperties.$vueSocketIo = this;
-    app.mixin(Mixin);
+        app.config.globalProperties.$socket = this.io;
+        app.config.globalProperties.$vueSocketIo = this;
+        app.mixin(Mixin);
 
         Logger.info('Vue-Socket.io plugin enabled');
 


### PR DESCRIPTION
The global property name change from `$socket` to `$http` still causes emit events to fail. Not sure if this was intentional.